### PR TITLE
minor optimizations

### DIFF
--- a/mlkem768.go
+++ b/mlkem768.go
@@ -683,10 +683,17 @@ func ntt(f ringElement) nttElement {
 		len := 256 >> bl
 		start := (k - 1<<(bl-1)) << (9 - bl)
 		zeta := zetas[k]
-		for j := start; j < start+len; j++ {
-			t := fieldMul(zeta, f[j+len])
-			f[j+len] = fieldSub(f[j], t)
-			f[j] = fieldAdd(f[j], t)
+		for j := start; j < start+len; j += 2 {
+			{
+				t := fieldMul(zeta, f[j+len])
+				f[j+len] = fieldSub(f[j], t)
+				f[j] = fieldAdd(f[j], t)
+			}
+			{
+				t := fieldMul(zeta, f[j+1+len])
+				f[j+1+len] = fieldSub(f[j+1], t)
+				f[j+1] = fieldAdd(f[j+1], t)
+			}
 		}
 	}
 	return nttElement(f)
@@ -701,10 +708,17 @@ func inverseNTT(f nttElement) ringElement {
 		len := 256 >> bl
 		start := (1<<bl - k - 1) << (9 - bl)
 		zeta := zetas[k]
-		for j := start; j < start+len; j++ {
-			t := f[j]
-			f[j] = fieldAdd(t, f[j+len])
-			f[j+len] = fieldMul(zeta, fieldSub(f[j+len], t))
+		for j := start; j < start+len; j += 2 {
+			{
+				t := f[j]
+				f[j] = fieldAdd(t, f[j+len])
+				f[j+len] = fieldMul(zeta, fieldSub(f[j+len], t))
+			}
+			{
+				t := f[j+1]
+				f[j+1] = fieldAdd(t, f[j+1+len])
+				f[j+1+len] = fieldMul(zeta, fieldSub(f[j+1+len], t))
+			}
 		}
 	}
 	for i := range f {

--- a/mlkem768.go
+++ b/mlkem768.go
@@ -446,8 +446,7 @@ func decompress(y uint16, d uint8) fieldElement {
 type ringElement [n]fieldElement
 
 // polyAdd adds two ringElements or nttElements.
-func polyAdd[T ~[n]fieldElement](a, b T) T {
-	var s T
+func polyAdd[T ~[n]fieldElement](a, b T) (s T) {
 	for i := range s {
 		s[i] = fieldAdd(a[i], b[i])
 	}
@@ -455,8 +454,7 @@ func polyAdd[T ~[n]fieldElement](a, b T) T {
 }
 
 // polySub subtracts two ringElements or nttElements.
-func polySub[T ~[n]fieldElement](a, b T) T {
-	var s T
+func polySub[T ~[n]fieldElement](a, b T) (s T) {
 	for i := range s {
 		s[i] = fieldSub(a[i], b[i])
 	}

--- a/mlkem768.go
+++ b/mlkem768.go
@@ -512,8 +512,7 @@ func sliceForAppend(in []byte, n int) (head, tail []byte) {
 	if total := len(in) + n; cap(in) >= total {
 		head = in[:total]
 	} else {
-		head = make([]byte, total)
-		copy(head, in)
+		head = append(in, make([]byte, n)...)
 	}
 	tail = head[len(in):]
 	return


### PR DESCRIPTION
These are all on the order of a percent or two on darwin/arm64,
so leaving it to you to decide whether they're worth it
(including checking impact on amd64). My 2c:

> - avoid extra data copies

Clearly generates better code. Almost no readability impact.

> - avoid extra zeroing

Probably a good idea, despite being weird.

> - reduce nested loops

Probably not worth it? But maybe interesting?

> - unroll ntt inner loop

Possibly the highest impact of the optimizations. Won't cherry-pick cleanly without "reduce nested loops", but the idea is simple and it is very easy to recreate.